### PR TITLE
Added --config argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
     power_menu::merge_config(
         &mut menu,
         &mut wofi,
-        wofi::get_config(env!("CARGO_BIN_NAME"))?,
+        wofi::get_config(env!("CARGO_BIN_NAME"), &args.config)?,
     )?;
     power_menu::merge_cli_args(&mut menu, &mut wofi, &args)?;
 

--- a/src/power_menu.rs
+++ b/src/power_menu.rs
@@ -36,6 +36,10 @@ pub struct CliArgs {
     #[arg(short, long)]
     pub list_items: bool,
 
+    /// Path for config file (Must be formatted as a .toml file)
+    #[arg(long)]
+    pub config: Option<String>,
+
     /// Switch to elogind
     #[arg(short, long, default_value_t = SessionManager::Systemd)]
     pub session_manager: SessionManager,
@@ -143,6 +147,7 @@ pub fn merge_config(menu: &mut Menu, wofi: &mut Wofi, config: Option<Config>) ->
         }
 
         if let Some(menu_config) = config.menu {
+            // dbg!(&menu);
             menu.merge(menu_config)?;
         }
     } else {

--- a/src/wofi.rs
+++ b/src/wofi.rs
@@ -5,8 +5,9 @@ use std::{
     fmt::Display,
     fs,
     io::{self, Write},
-    path::Path,
+    path::{Path, PathBuf},
     process::Stdio,
+    str::FromStr,
 };
 
 use crate::icons::{CANCEL, FSI, LRI, LRM, PDI};
@@ -340,13 +341,20 @@ impl Wofi {
     }
 }
 
-pub fn get_config(file_name: impl Into<String>) -> anyhow::Result<Option<Config>> {
-    let base_dirs =
-        directories_next::BaseDirs::new().ok_or_else(|| anyhow!("Error reading config"))?;
-
-    let path = base_dirs
-        .config_dir()
-        .join(format!("{}.toml", file_name.into()));
+pub fn get_config(
+    file_name: impl Into<String>,
+    config_path: &Option<String>,
+) -> anyhow::Result<Option<Config>> {
+    
+    let path = match config_path {
+        // If --config <CONFIG> was passed, use the specified toml config file
+        Some(path) => PathBuf::from_str(&path)?,
+        // Else default to $HOME/.config/wofi-power-menu.toml
+        None => directories_next::BaseDirs::new()
+            .ok_or_else(|| anyhow!("Error reading config"))?
+            .config_dir()
+            .join(format!("{}.toml", file_name.into())),
+    };
 
     Config::read(path)
 }


### PR DESCRIPTION
Added --config argument to Args struct as a Option<String>. If provided, reads from args.config as a PathBuf, else defaults to .config_dir() like before.