### PR TITLE
docs: Add instruction how to install prebuilt AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Add to your `configuration.nix`:
 
 ### Arch Linux
 
+#### From sources
+
 You can install this project using an [unofficial AUR
 package](https://aur.archlinux.org/packages/wofi-power-menu) (Thanks
 [@AsfhtgkDavid](https://github.com/AsfhtgkDavid)):
@@ -59,6 +61,28 @@ Alternatively, you can build from the AUR manually:
 git clone https://aur.archlinux.org/wofi-power-menu.git
 cd wofi-power-menu
 makepkg -si
+```
+
+#### Prebuilt
+
+If you don't want to spend time building it, you can download the prebuilt version:
+
+```bash
+yay -S wofi-power-menu-bin
+```
+
+Alternatively, you can install from the AUR manually:
+
+```bash
+git clone https://aur.archlinux.org/wofi-power-menu-bin.git
+cd wofi-power-menu-bin
+makepkg -si
+```
+
+You may need to download GPG keys:
+
+```bash
+gpg --recv-keys 42BE68F43D528467FC281E2E310FFE86A2E427BA
 ```
 
 ### Download Pre-built Binary
@@ -81,8 +105,7 @@ You can download the latest pre-built binary from the [GitHub releases page](htt
 
    ```bash
    # Download and import the public key
-   curl -LO https://github.com/szaffarano/wofi-power-menu/raw/master/KEYS
-   gpg --import KEYS
+   gpg --recv-keys 42BE68F43D528467FC281E2E310FFE86A2E427BA
    ```
 
 3. **Verify the signature:**


### PR DESCRIPTION
Hi, as you might remember, I had previously published your project to the AUR. Today I’ve decided to also provide a binary package on the AUR, since you already publish binaries and this makes installation faster.

In addition, I updated the command for fetching your key — I switched it to use the keyserver instead of downloading it directly from the repository, as I think this is a more convenient approach.