### PR TITLE
chore: Prepare v0.3.3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,102 +1,90 @@
 name: Release
-
 on:
   push:
     tags:
-      - 'v*'
-
+      - "v*"
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    
     steps:
-    - uses: actions/checkout@v6
-    
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: x86_64-unknown-linux-gnu
-    
-    - name: Cache cargo registry
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-    
-    - name: Cache target directory
-      uses: actions/cache@v4
-      with:
-        path: target/
-        key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-target-
-    
-    - name: Build release
-      run: cargo build --release --target x86_64-unknown-linux-gnu
-    
-    - name: Prepare binary
-      run: |
-        cp target/x86_64-unknown-linux-gnu/release/wofi-power-menu wofi-power-menu-linux-x64
-    
-    - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@v6
-      with:
-        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.GPG_PASSPHRASE }}
-    
-    - name: Sign artifacts
-      run: |
-        gpg --armor --detach-sign wofi-power-menu-linux-x64
-        sha256sum wofi-power-menu-linux-x64 > wofi-power-menu-linux-x64.sha256
-        gpg --armor --detach-sign wofi-power-menu-linux-x64.sha256
-    
-    - name: Generate Release Notes
-      id: release_notes
-      uses: mikepenz/release-changelog-builder-action@v6
-      with:
-        configuration: |
-          {
-            "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>#{{CONTRIBUTORS}}",
-            "categories": [
-              {
-                  "title": "## Feature",
-                  "labels": ["feat", "feature"]
-              },
-              {
-                  "title": "## Fix",
-                  "labels": ["fix", "bug"]
-              },
-              {
-                  "title": "## Other",
-                  "labels": []
-              }
-            ],
-            "label_extractor": [
-              {
-                "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-                "on_property": "title",
-                "target": "$1"
-              }
-            ]
-          }
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Create Release
-      uses: softprops/action-gh-release@v2
-      with:
-        body: ${{ steps.release_notes.outputs.changelog }}
-        files: |
-          wofi-power-menu-linux-x64
-          wofi-power-menu-linux-x64.asc
-          wofi-power-menu-linux-x64.sha256
-          wofi-power-menu-linux-x64.sha256.asc
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v6
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target/
+          key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-target-
+      - name: Build release
+        run: cargo build --release --target x86_64-unknown-linux-gnu
+      - name: Prepare binary
+        run: |
+          cp target/x86_64-unknown-linux-gnu/release/wofi-power-menu wofi-power-menu-linux-x64
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Sign artifacts
+        run: |
+          gpg --armor --detach-sign wofi-power-menu-linux-x64
+          sha256sum wofi-power-menu-linux-x64 > wofi-power-menu-linux-x64.sha256
+          gpg --armor --detach-sign wofi-power-menu-linux-x64.sha256
+      - name: Generate Release Notes
+        id: release_notes
+        uses: mikepenz/release-changelog-builder-action@v6
+        with:
+          configuration: |
+            {
+              "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>#{{CONTRIBUTORS}}",
+              "categories": [
+                {
+                    "title": "## Feature",
+                    "labels": ["feat", "feature"]
+                },
+                {
+                    "title": "## Fix",
+                    "labels": ["fix", "bug"]
+                },
+                {
+                    "title": "## Other",
+                    "labels": []
+                }
+              ],
+              "label_extractor": [
+                {
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+                  "on_property": "title",
+                  "target": "$1"
+                }
+              ]
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.release_notes.outputs.changelog }}
+          files: |
+            wofi-power-menu-linux-x64
+            wofi-power-menu-linux-x64.asc
+            wofi-power-menu-linux-x64.sha256
+            wofi-power-menu-linux-x64.sha256.asc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wofi-power-menu"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wofi-power-menu"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Sebastián Zaffarano sebas@zaffarano.com.ar"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -94,31 +94,33 @@ You can download the latest pre-built binary from the [GitHub releases page](htt
    ```bash
    # Download the binary
    curl -LO https://github.com/szaffarano/wofi-power-menu/releases/latest/download/wofi-power-menu-linux-x64
-   
+
+
    # Download verification files
    curl -LO https://github.com/szaffarano/wofi-power-menu/releases/latest/download/wofi-power-menu-linux-x64.asc
    curl -LO https://github.com/szaffarano/wofi-power-menu/releases/latest/download/wofi-power-menu-linux-x64.sha256
    curl -LO https://github.com/szaffarano/wofi-power-menu/releases/latest/download/wofi-power-menu-linux-x64.sha256.asc
    ```
 
-2. **Import the PGP public key:**
+1. **Import the PGP public key:**
 
    ```bash
    # Download and import the public key
    gpg --recv-keys 42BE68F43D528467FC281E2E310FFE86A2E427BA
    ```
 
-3. **Verify the signature:**
+1. **Verify the signature:**
 
    ```bash
    # Verify the signed checksum
    gpg --verify wofi-power-menu-linux-x64.sha256.asc wofi-power-menu-linux-x64.sha256
-   
+
+
    # Verify the binary checksum
    sha256sum -c wofi-power-menu-linux-x64.sha256
    ```
 
-4. **Install the binary:**
+1. **Install the binary:**
 
    ```bash
    # Make executable and move to PATH
@@ -148,6 +150,7 @@ cargo install --path .
 ```
 
 Requirements:
+
 - Rust 1.70 or newer
 - [wofi](https://sr.ht/~scoopta/wofi/) installed on your system
 
@@ -177,7 +180,7 @@ Options:
   -V, --version                Print version
 ```
 
-example
+Example
 
 ```bash
 # list items

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1758108966,
-        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "lastModified": 1763988335,
+        "narHash": "sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh+M4Qc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "rev": "50b9238891e388c9fdc6a5c49e49c42533a1b5ce",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758029226,
-        "narHash": "sha256-TjqVmbpoCqWywY9xIZLTf6ANFvDCXdctCjoYuYPYdMI=",
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08b8f92ac6354983f5382124fef6006cade4a1c1",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1758198701,
-        "narHash": "sha256-7To75JlpekfUmdkUZewnT6MoBANS0XVypW6kjUOXQwc=",
+        "lastModified": 1763966396,
+        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0147c2f1d54b30b5dd6d4a8c8542e8d7edf93b5d",
+        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1754340878,
-        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "lastModified": 1761236834,
+        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758249250,
-        "narHash": "sha256-bg228atm49IZ8koNOlT3bsrFKE9sFjq6vn6Tx8eVgpc=",
+        "lastModified": 1764211126,
+        "narHash": "sha256-p5y13PnMZYd5WdHk+XCzyUaLGBUCwnz2n4KYKEZM0Pw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e26a009e7edab102bd569dc041459deb6c0009f4",
+        "rev": "895935bff08cfcfb663fb9c8263c43596e7cd1ed",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1758206697,
-        "narHash": "sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0=",
+        "lastModified": 1762938485,
+        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "128222dc911b8e2e18939537bed1762b7f3a04aa",
+        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- **flake.lock: Update**
- **fix: md lint**
- **fix: yaml lint**
- **chore: Bump cargo version**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps to v0.3.3, refreshes Nix flake.lock, and tidies release workflow YAML and README formatting.
> 
> - **Release/Versioning**:
>   - Bump `wofi-power-menu` to `0.3.3` in `Cargo.toml` and `Cargo.lock`.
> - **CI/Release**:
>   - Normalize `.github/workflows/release.yml` syntax/quoting; build, signing, and release steps retained.
> - **Docs**:
>   - Fix README numbering/capitalization and spacing in download/install sections.
> - **Nix**:
>   - Update `flake.lock` inputs (`nixpkgs`, `flake-parts`, `git-hooks.nix`, `rust-overlay`, `treefmt-nix`, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85c5277fc0836c0f20ad39baf08b1b75311dcd48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->