### PR TITLE
chore(release): Prepare v0.3.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wofi-power-menu"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wofi-power-menu"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["Sebastián Zaffarano sebas@zaffarano.com.ar"]
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a release/version bump only, with no functional or dependency changes beyond updating the crate version metadata.
> 
> **Overview**
> Bumps the crate version from `0.3.3` to `0.3.4` in `Cargo.toml` and updates `Cargo.lock` to match for the v0.3.4 release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7739a2aaee6c88b9c39c48f43460765fa22cc398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->